### PR TITLE
Improve Gemini error handling

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,6 +3,7 @@ import re
 import datetime
 from flask import Flask, render_template, request, jsonify, session, redirect, url_for
 import google.generativeai as genai
+from google.generativeai.types import RequestOptions
 from dotenv import load_dotenv
 import random
 
@@ -233,7 +234,10 @@ def get_gemini_word():
 
     try:
         while True:
-            response = model.generate_content(prompt_to_send)
+            response = model.generate_content(
+                prompt_to_send,
+                request_options=RequestOptions(timeout=10)
+            )
             gemini_word = response.text.strip()
             gemini_word = re.sub(r'^[はい、そうです、\s]*[単語は、](「|『)?(.+?)(」|』)?(です)?(。)?$', r'\2', gemini_word)
             gemini_word = re.sub(r'[「」『』（）。、\s]', '', gemini_word)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Flask
 google-generativeai
+python-dotenv


### PR DESCRIPTION
## Summary
- add `python-dotenv` to requirements
- use `RequestOptions(timeout=10)` in Gemini API call to avoid hanging

## Testing
- `python3 -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68529cd480188320b0c6524c0d57ec64