### PR TITLE
Keep difficulty selection and highlight button

### DIFF
--- a/app.py
+++ b/app.py
@@ -72,11 +72,11 @@ def save_game_state(state):
     session['game_state'] = state
 
 def reset_game_state():
-    """ゲーム状態を初期化する。"""
-    
-    session.pop('game_state', None) 
-    
+    """ゲーム状態を初期化するが、現在のレベルは維持する。"""
+
+    current_level = session.get('game_state', {}).get('level', DEFAULT_GAME_STATE['level'])
     session['game_state'] = DEFAULT_GAME_STATE.copy()
+    session['game_state']['level'] = current_level
 
 
 

--- a/static/level.js
+++ b/static/level.js
@@ -1,43 +1,66 @@
 document.addEventListener('DOMContentLoaded', () => {
-    
     const easyButton = document.getElementById('easy-button');
     const mediumButton = document.getElementById('medium-button');
     const hardButton = document.getElementById('hard-button');
 
-    
-    [easyButton, mediumButton, hardButton].forEach(button => {
-        if (button) { 
-            button.addEventListener('click', async () => {
-                const selectedLevel = button.dataset.level; 
-                console.log(`Selected Level: ${selectedLevel}`);
+    const buttons = [easyButton, mediumButton, hardButton];
 
-                try {
-                    
-                    const response = await fetch(SELECT_LEVEL_URL, {
-                        method: 'POST',
-                        headers: {
-                            'Content-Type': 'application/json'
-                        },
-                        body: JSON.stringify({ level: selectedLevel })
-                    });
+    function updateButtonImages(activeLevel) {
+        buttons.forEach(btn => {
+            if (!btn) return;
+            const img = btn.querySelector('img');
+            if (btn.dataset.level === activeLevel) {
+                img.src = img.dataset.on;
+            } else {
+                img.src = img.dataset.off;
+            }
+        });
+    }
 
-                    if (!response.ok) {
-                        throw new Error(`HTTP error! status: ${response.status}`);
-                    }
-
-                    const data = await response.json();
-                    if (data.status === 'success') {
-                        alert(`レベルを「${data.level}」に設定しました！`);
-                        
-                        window.location.href = PLAY_PAGE_URL;
-                    } else {
-                        alert(`レベル設定に失敗しました: ${data.message}`);
-                    }
-                } catch (error) {
-                    console.error('レベル設定中にエラーが発生しました:', error);
-                    alert('レベル設定中に通信エラーが発生しました。');
-                }
-            });
+    async function fetchCurrentLevel() {
+        try {
+            const res = await fetch(GET_GAME_STATUS_URL);
+            if (!res.ok) {
+                throw new Error(`HTTP error! status: ${res.status}`);
+            }
+            const data = await res.json();
+            updateButtonImages(data.level);
+        } catch (e) {
+            console.error('現在のレベル取得に失敗しました:', e);
         }
+    }
+
+    buttons.forEach(button => {
+        if (!button) return;
+        button.addEventListener('click', async () => {
+            const selectedLevel = button.dataset.level;
+
+            try {
+                const response = await fetch(SELECT_LEVEL_URL, {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json'
+                    },
+                    body: JSON.stringify({ level: selectedLevel })
+                });
+
+                if (!response.ok) {
+                    throw new Error(`HTTP error! status: ${response.status}`);
+                }
+
+                const data = await response.json();
+                if (data.status === 'success') {
+                    alert(`レベルを「${data.level}」に設定しました！`);
+                    updateButtonImages(data.level);
+                } else {
+                    alert(`レベル設定に失敗しました: ${data.message}`);
+                }
+            } catch (error) {
+                console.error('レベル設定中にエラーが発生しました:', error);
+                alert('レベル設定中に通信エラーが発生しました。');
+            }
+        });
     });
+
+    fetchCurrentLevel();
 });

--- a/templates/level.html
+++ b/templates/level.html
@@ -35,13 +35,25 @@
             <h2>対戦相手の難易度</h2>
             <div class="level-buttons">
                 <button id="easy-button" class="level-button" data-level="easy">
-                    <img src="{{ url_for('static', filename='images/Off_Button_Easy.png') }}" alt="Easyレベルを選択"/>
+                    <img
+                        src="{{ url_for('static', filename='images/Off_Button_Easy.png') }}"
+                        data-off="{{ url_for('static', filename='images/Off_Button_Easy.png') }}"
+                        data-on="{{ url_for('static', filename='images/On_Button_Easy.png') }}"
+                        alt="Easyレベルを選択"/>
                 </button>
                 <button id="medium-button" class="level-button" data-level="medium">
-                    <img src="{{ url_for('static', filename='images/Off_Button_Medium.png') }}" alt="Mediumレベルを選択"/>
+                    <img
+                        src="{{ url_for('static', filename='images/Off_Button_Medium.png') }}"
+                        data-off="{{ url_for('static', filename='images/Off_Button_Medium.png') }}"
+                        data-on="{{ url_for('static', filename='images/On_Button_Medium.png') }}"
+                        alt="Mediumレベルを選択"/>
                 </button>
                 <button id="hard-button" class="level-button" data-level="hard">
-                    <img src="{{ url_for('static', filename='images/Off_Button_Hard.png') }}" alt="Hardレベルを選択"/>
+                    <img
+                        src="{{ url_for('static', filename='images/Off_Button_Hard.png') }}"
+                        data-off="{{ url_for('static', filename='images/Off_Button_Hard.png') }}"
+                        data-on="{{ url_for('static', filename='images/On_Button_Hard.png') }}"
+                        alt="Hardレベルを選択"/>
                 </button>
             </div>
             <nav>
@@ -54,7 +66,7 @@
         <script>
             // JavaScript変数をHTML内で定義
             const SELECT_LEVEL_URL = "{{ url_for('select_level') }}";
-            const PLAY_PAGE_URL = "{{ url_for('play') }}"; // レベル選択後、プレイページへ遷移するため
+            const GET_GAME_STATUS_URL = "{{ url_for('get_game_status') }}";
         </script>
         <script src="{{ url_for('static', filename='level.js') }}"></script>
         <script src="{{ url_for('static', filename='side-menu.js') }}"></script>


### PR DESCRIPTION
## Summary
- maintain level selection when resetting game state
- highlight selected level without redirecting to /play
- show current level selection when loading the level page

## Testing
- `python3 -m py_compile app.py`
- `node --check static/level.js`
- `node --check static/play.js`


------
https://chatgpt.com/codex/tasks/task_e_685238f138448320afb36b2dc939b6b0